### PR TITLE
Make async calls to Meilisearch

### DIFF
--- a/my_api/main.py
+++ b/my_api/main.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from contextlib import asynccontextmanager
 import os
 import asyncio
-from meilisearch import Client
+from meilisearch_python_sdk import AsyncClient
 from meilisearch.errors import MeilisearchApiError
 from fastapi import FastAPI, Depends, HTTPException, status
 from pydantic import PositiveInt
@@ -15,20 +15,23 @@ from my_api.schemas import CreatePost, RetrievePost
 from my_api.search_sync import BackgroundSearchSyncer
 
 
-def get_search_client():
-    client = Client(url=os.environ.get("SEARCH_INDEX_URL"), 
-                    api_key=os.environ.get("SEARCH_INDEX_KEY")
-                )
+async def get_search_client():
+    client = AsyncClient(
+        url=os.environ.get("SEARCH_INDEX_URL"),
+        api_key=os.environ.get("SEARCH_INDEX_KEY"),
+    )
     try:
-        client.health()
+        await client.health()
         yield client
     except MeilisearchApiError:
         print("Check something.")
 
-SearchDep = Annotated[Client, Depends(get_search_client)]
+
+SearchDep = Annotated[AsyncClient, Depends(get_search_client)]
 
 
 runner = BackgroundSearchSyncer()
+
 
 # tables created with alembic at start
 @asynccontextmanager
@@ -52,60 +55,72 @@ async def check_db_alive(db: SessionDep):
     return cr.check_alive(db)
 
 
-@app.post("/post/", response_model = RetrievePost)
-async def create_post(db: SessionDep, p_info:CreatePost):
+@app.post("/post/", response_model=RetrievePost)
+async def create_post(db: SessionDep, p_info: CreatePost):
     post = cr.create_post(db, p_info)
     return post
 
-@app.get("/post/{p_id}", response_model = RetrievePost)
+
+@app.get("/post/{p_id}", response_model=RetrievePost)
 async def get_post(db: SessionDep, p_id: PositiveInt):
     post = cr.get_post_by_id(db, p_id)
     if post is None or post.is_deleted:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Post {p_id} not found.")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"Post {p_id} not found."
+        )
     return post
 
-@app.delete("/post/{p_id}", response_model = RetrievePost)
+
+@app.delete("/post/{p_id}", response_model=RetrievePost)
 async def ghost_delete_post(db: SessionDep, p_id: PositiveInt):
     post = cr.get_post_by_id(db, p_id)
     if post is None or post.is_deleted:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Post {p_id} not found.")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"Post {p_id} not found."
+        )
     post = cr.ghost_delete_post(db, p_id)
     return post
 
-@app.delete("/secret/post/{p_id}", response_model = RetrievePost)
+
+@app.delete("/secret/post/{p_id}", response_model=RetrievePost)
 async def actually_delete_post(db: SessionDep, client: SearchDep, p_id: PositiveInt):
     post = cr.get_post_by_id(db, p_id)
     if post is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Post {p_id} not found.")
-    client.index(SEARCH_INDEX_NAME).delete_document(p_id)
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"Post {p_id} not found."
+        )
+    await client.index(SEARCH_INDEX_NAME).delete_document(str(p_id))
     post = cr.delete_post(db, p_id)
     return post
 
 
-
 @app.get("/search_health/")
 async def check_search_connection(client: SearchDep):
-    return client.health()
+    return await client.health()
+
 
 @app.post("/search_index/")
 async def create_search_index(client: SearchDep):
-    return client.create_index(uid=SEARCH_INDEX_NAME)
+    return await client.create_index(uid=SEARCH_INDEX_NAME)
+
 
 @app.delete("/search_index/")
 async def delete_search_index(client: SearchDep):
-    return client.delete_index(uid=SEARCH_INDEX_NAME)
+    return await client.index(uid=SEARCH_INDEX_NAME).delete()
+
 
 @app.get("/search_index/")
 async def get_search_index(client: SearchDep):
     try:
-        return client.get_index(uid=SEARCH_INDEX_NAME)
+        return await client.get_index(uid=SEARCH_INDEX_NAME)
     except MeilisearchApiError as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)
+
 
 @app.delete("/search_index/documents/all/")
 async def delete_all_documents_in_search_index(client: SearchDep):
     try:
-        return client.index(uid=SEARCH_INDEX_NAME).delete_all_documents()
+        return await client.index(uid=SEARCH_INDEX_NAME).delete_all_documents()
     except MeilisearchApiError as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)
 
@@ -118,6 +133,6 @@ async def read_value():
 @app.get("/search_index/{doc_id}")
 async def get_document(doc_id: PositiveInt, client: SearchDep):
     try:
-        return client.index(SEARCH_INDEX_NAME).get_document(doc_id)
+        return await client.index(SEARCH_INDEX_NAME).get_document(str(doc_id))
     except MeilisearchApiError as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "fastapi[all]",
     "cloud-sql-python-connector[pg8000]",
     "sqlalchemy",
-    "meilisearch",
+    "meilisearch-python-sdk",
     "pytest",       # testing
     "ruff"          # linting
 ]


### PR DESCRIPTION
By switching from the `meilisearch` package to `meilisearch-python-sdk` you can make your calls to Meilisearch async and not block the event loop.

Disclaimer: I am the creater and maintainer of `meilisearch-python-sdk`, but I am also a mainteainer of the `meilisearch` package so I don't have any bias for one over the other. I only suggest you switch because it is better for your use case.